### PR TITLE
Sprockets 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source "http://rubygems.org"
 
 gem "sinatra", :require => "sinatra/base"
 
-gem 'coffee-script'
-gem "uglifier"
-gem "sass"
-gem "sprockets"
+gem 'coffee-script', '~>2.2.0'
+gem "uglifier", '~>1.0.3'
+gem "sass", '~>3.1.10'
+gem "sprockets", '~>2.0.2'
 
 group :test, :development do
   gem 'guard-sprockets2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,28 +5,31 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.1.2)
-    execjs (1.2.6)
+    execjs (1.2.9)
       multi_json (~> 1.0)
-    growl_notify (0.0.1)
+    growl_notify (0.0.3)
       rb-appscript
-    guard (0.7.0)
+    guard (0.8.4)
       thor (~> 0.14.6)
-    guard-sprockets2 (0.0.4)
+    guard-sprockets2 (0.0.5)
       guard
       sprockets (~> 2.0)
     hike (1.2.1)
     multi_json (1.0.3)
-    rack (1.3.3)
+    rack (1.3.4)
+    rack-protection (1.1.4)
+      rack
     rb-appscript (0.6.1)
     rb-fsevent (0.4.3.1)
-    sass (3.1.7)
-    sinatra (1.2.6)
-      rack (~> 1.1)
-      tilt (< 2.0, >= 1.2.2)
-    sprockets (2.0.0)
+    sass (3.1.10)
+    sinatra (1.3.1)
+      rack (~> 1.3, >= 1.3.4)
+      rack-protection (~> 1.1, >= 1.1.2)
+      tilt (~> 1.3, >= 1.3.3)
+    sprockets (2.0.2)
       hike (~> 1.2)
       rack (~> 1.0)
-      tilt (!= 1.3.0, ~> 1.1)
+      tilt (~> 1.1, != 1.3.0)
     thor (0.14.6)
     tilt (1.3.3)
     uglifier (1.0.3)
@@ -37,11 +40,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  coffee-script
+  coffee-script (~> 2.2.0)
   growl_notify
   guard-sprockets2
   rb-fsevent
-  sass
+  sass (~> 3.1.10)
   sinatra
-  sprockets
-  uglifier
+  sprockets (~> 2.0.2)
+  uglifier (~> 1.0.3)

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@ Bundler.require
 
 module AssetHelpers
   def asset_path(source)
-    settings.sprockets.path(source, true, "assets")
+    "/assets/" + settings.sprockets.find_asset(source).digest_path
   end
 end
 


### PR DESCRIPTION
Sprockets.path is no longer available, sprockets.find_asset('asset').digest_path should be used instead

Sprockets.path which was deprecated and has been removed as of Sprockets 2.0.1 in the commit https://github.com/sstephenson/sprockets/commit/00ca11e6943b5270d2f7bde94a4729927ce9ce6a

c.f https://github.com/sstephenson/sprockets/issues/222
